### PR TITLE
Feature/make vla optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ If you want to disable variable length array used in the framework,
 either due to compiler doesn't support or some other reason,
 then `HSM_USE_VARIABLE_LENGTH_ARRAY` to 0.
 
-If you disable "variable length array" then you need to manually provide the maximum hierarchical level of all the state machines.
-use `MAX_HIERARCHICAL_LEVEL` to set the maximum hierarchical level. This should be highest `state_t::Level` value of all the state machines.
+If you disable "variable length array" then you need to manually provide the highest value of hierarchical level among all the state machines.
+use `MAX_HIERARCHICAL_LEVEL` to set the maximum hierarchical level. This should be highest `state_t::Level` value among all the state machines.
 
 By default, framework uses variable length array implementation.
 ```C

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 UML State Machine in C
 ======================
 
-This is a lightweight framework for UML state machine implemented in C. It supports both finite and hierarchical state machine. The framework is independent of CPU, operating systems and it is developed specifically for embedded application in mind.
+This is a lightweight framework for UML state machine implemented in C. It supports both finite and hierarchical state machines. The framework is independent of CPU, operating systems and it is developed specifically for embedded application in mind.
 
 - The framework is very minimalistic. It has only 3 API's, 2 structures and 1 enumeration.
-- It uses only **116** bytes[1] of code memory for finite state machine and **424** bytes[1] of code memory for hierarchical state machine. It doesn't use any data memory for the framework itself.
+- It uses only **116** bytes[1] of code memory for finite state machine and **424** bytes[1] of code memory for a hierarchical state machine. It doesn't use any data memory for the framework itself.
 > [1]Compiled in IAR ARM 8.30 compiler in release mode.
 
 The framework contains three files
@@ -13,7 +13,7 @@ The framework contains three files
 3. hsm_config.h : Compile-time configuration of framework.
 
 To read more about finite state machine and hierarchical state machine please go through the following links.
-<https://en.wikipedia.org/wiki/UML_state_machine>  
+<https://en.wikipedia.org/wiki/UML_state_machine>
 <https://en.wikipedia.org/wiki/Finite-state_machine>
 
 
@@ -48,11 +48,11 @@ struct user_state_machine
 
 ### Event
  Event is represented by 32-bit unsigned int. The `Event` field in the `state_machine_t` holds the event value to pass it to the state machine. The `Event` (in `state_machine_t`) equal to zero indicates that state machine is ready to accept new event. Write any non-zero value in the `Event` to pass it to the state machine. The framework clears the Event when state machine processes it successfully. Do not write new event value, when the `Event` field in the `state_machine_t` is not zero.
-In this case you need to implement Queue in the state machine to push the new event value when state machine is still busy in processing the event.
+In this case, you need to implement Queue in the state machine to push the new event value when state machine is still busy processing the event.
 
 
 ### State
-State is represented by pointer to `state_t` structure in the framework.
+State is represented by a pointer to `state_t` structure in the framework.
 
 If framework is configured for finite state machine then `state_t` contains,
 
@@ -74,7 +74,7 @@ typedef struct finite_state_t{
 >The Handler must be initialized.
 >The Entry and Exit actions are optional and can be initialized to NULL if not required.
 
-If framework is configured to support hierarchical state machine. It contains additional three members to represent the hierarchical relation between the states.
+If a framework is configured to support hierarchical state machine. It contains additional three members to represent the hierarchical relation between the states.
 
 ```C
 typedef struct hierarchical_state_t state_t;
@@ -97,8 +97,8 @@ typedef struct hierarchical_state_t
 - Node:   pointer to child state of the current state
 - Level:  Hierarchical level of state from root. Root state has level zero.
 
-The states can be created compile-time and no additional functions from framework is required for generation of states.
-In addition they can be defined as **const** so that it stored in the read only memory.
+The states can be created compile-time and no additional functions from framework are required for generation of states.
+In addition, they can be defined as **const** so that it stored in the read only memory.
 
 
 event dispatcher
@@ -121,7 +121,7 @@ typedef enum
 {
   EVENT_HANDLED,      //!< Event handled successfully.
   EVENT_UN_HANDLED,    //!< Event could not be handled.
-  //!< Handler handled the Event successfully, and posted new event to itself.
+  //!< Handler handled the Event successfully and posted new event to itself.
   TRIGGERED_TO_SELF,
 }state_machine_result_t;
 ```
@@ -152,7 +152,7 @@ The framework supports two types of state transition,
 state_machine_result_t switch_state(state_machine_t* const pState_Machine, const state_t* pTarget_State);
 ```
 
-   Use this function when framework is configured for finite state machine. You can also use this function in hierarchical state machine if the source and target states have common parent state. It calls the exit action of source state and then calls the entry action of target state in the state transition.
+   Use this function when framework is configured for finite state machine. You can also use this function in hierarchical state machine if the source and target states have a common parent state. It calls the exit action of source state and then calls the entry action of target state in the state transition.
 
 2. traverse_state:
 
@@ -163,10 +163,16 @@ state_machine_result_t traverse_state(state_machine_t* const pState_Machine, con
 
 Configuration
 -------------
-The framework can be configured to support either **finite state machine** or **hierarchical state machine** using a macro in hsm_config.h file.
 
-By default the framework supports hierarchical state machine. Use "hsm_config.h" file to customize the framework.
-To change the default configuration define macro `HSM_CONFIG` using compiler -D option and provide path to "hsm_config.h" file.
+The framework can be configured to support different use cases.
+To change the default configuration, define a macro `HSM_CONFIG` using compiler -D option and provide a path to "hsm_config.h" file.
+Add your configuration in hsm_config.h to override the default configuration in the hsm.h.
+Modifying hsm.h for configuration is not recommended.
+
+### finite/hierarchical state machine
+
+The framework can be configured to support either **finite state machine** or **hierarchical state machine** using a macro in hsm_config.h file.
+By default, the framework supports hierarchical state machine. Use "hsm_config.h" file to customize the framework.
 
 Change the value of `HIERARCHICAL_STATES` (in the "hsm_config.h") to enable/disable **hierarchical state machine**.
 
@@ -177,7 +183,10 @@ Change the value of `HIERARCHICAL_STATES` (in the "hsm_config.h") to enable/disa
 #define  HIERARCHICAL_STATES      0
 ```
 
+### Enable logging
+
 Change the value of `STATE_MACHINE_LOGGER` to enable/disable state machine logging.
+By default, logging is disabled.
 
 ```C
 // Enable the state machine logging
@@ -186,11 +195,29 @@ Change the value of `STATE_MACHINE_LOGGER` to enable/disable state machine loggi
 #define STATE_MACHINE_LOGGER     1
 ```
 
+### Disable Variable length array
+
+The `traverse_state` function uses variable length array feature in the implementaion of hierarchical state machine.
+If you want to disable variable length array used in the framework,
+either due to compiler doesn't support or some other reason,
+then `HSM_USE_VARIABLE_LENGTH_ARRAY` to 0.
+
+If you disable "variable length array" then you need to manually provide the maximum hierarchical level of all the state machines.
+use `MAX_HIERARCHICAL_LEVEL` to set the maximum hierarchical level. This should be highest `state_t::Level` value of all the state machines.
+
+By default, framework uses variable length array implementation.
+```C
+// Enable the state machine logging
+// 0: disable variable length array used in hsm.c
+// 1: enable variable length aray used in
+#define HSM_USE_VARIABLE_LENGTH_ARRAY 1
+```
+
 State machine logging
 ---------------------
 
 The framework supports the logging mechanism for debugging purpose using two callback functions.
-User need to implement logger functions and pass it to `dispatch_event`.
+User needs to implement logger functions and pass it to `dispatch_event`.
 
 ```C
 typedef void (*state_machine_event_logger)(uint32_t state_machine, uint32_t state, uint32_t event);
@@ -209,20 +236,20 @@ This function is called after dispatching the event to state machine. The framew
 - state: unique id of the current state after handling of the event.
 - result: Result of event handled by state machine.
 
-user can use this logging mechanism to also log the time consumed to handle the event by state machine.
+Users can use this logging mechanism to also log the time consumed to handle the event by state machine.
 Start timer on `state_machine_event_logger` and stop on `state_machine_result_logger`.
 
 ### Demo
-[simple state machine](demo/simple_state_machine/readme.md)  
+[simple state machine](demo/simple_state_machine/readme.md)
 [simple state machine (enhanced)](demo/simple_state_machine_enhanced/readme.md)
 
 ### Todo
 - Add more real world examples/demo's specially related to embedded systems
-- Add support of cmake so that different types of IDE and compilers can be supported in the demo's
+- Add support of CMake so that different types of IDE and compilers can be supported in the demo's
 - Add support of continuous integration
 
 ### More
-- For reporting issues/bugs or requesting featuers use GitHub issue tracker
-- for discussion, questions or feedback use  
+- For reporting issues/bugs or requesting features use GitHub issue tracker
+- for discussion, questions or feedback use
    https://groups.google.com/forum/#!forum/minimalist-uml-state-machine-in-c
 

--- a/src/hsm.c
+++ b/src/hsm.c
@@ -175,7 +175,18 @@ state_machine_result_t traverse_state(state_machine_t* const pState_Machine,
   bool triggered_to_self = false;
   pState_Machine->State = pTarget_State;    // Save the target node
 
+#if (HSM_USE_VARIABLE_LENGTH_ARRAY == 1)
   const state_t *pTarget_Path[pTarget_State->Level];  // Array to store the target node path
+#else
+  #if  (!defined(MAX_HIERARCHICAL_LEVEL) || (MAX_HIERARCHICAL_LEVEL == 0))
+  #error "MAX_HIERARCHICAL_LEVEL is undefined."\
+         "Define the maximum hierarchical level of the state machine or \
+          use variable length array by setting HSM_USE_VARIABLE_LENGTH_ARRAY to 1"
+  #endif
+
+  const state_t* pTarget_Path[MAX_HIERARCHICAL_LEVEL];     // Array to store the target node path
+#endif
+
   uint32_t index = 0;
 
   // make the source state & target state at the same hierarchy level.

--- a/src/hsm.h
+++ b/src/hsm.h
@@ -32,6 +32,10 @@
 #define STATE_MACHINE_LOGGER     0        //!< Disable the logging of state machine
 #endif // STATE_MACHINE_LOGGER
 
+#ifndef HSM_USE_VARIABLE_LENGTH_ARRAY
+#define HSM_USE_VARIABLE_LENGTH_ARRAY 1
+#endif
+
 /*
  *  --------------------- ENUMERATION ---------------------
  */
@@ -41,7 +45,7 @@ typedef enum
 {
   EVENT_HANDLED,      //!< Event handled successfully.
   EVENT_UN_HANDLED,    //!< Event could not be handled.
-  //!< Handler handled the Event successfully, and posted new event to itself.
+  //!< Handler handled the Event successfully and posted new event to itself.
   TRIGGERED_TO_SELF,
 }state_machine_result_t;
 

--- a/test/build/hsm_test/codeclocks/hsm_test.cbp
+++ b/test/build/hsm_test/codeclocks/hsm_test.cbp
@@ -31,9 +31,6 @@
 		<Compiler>
 			<Add option="-Wall" />
 			<Add option="-std=c11" />
-			<Add option="-std=c++14" />
-			<Add option="-fms-extensions" />
-			<Add option="-fpermissive" />
 			<Add option="-DHSM_CONFIG" />
 			<Add directory="../../../src" />
 			<Add directory="../../../../src" />

--- a/test/build/hsm_test/codeclocks/hsm_test.depend
+++ b/test/build/hsm_test/codeclocks/hsm_test.depend
@@ -2663,18 +2663,18 @@
 1539911761 source:e:\bala\project\uml-state-machine-in-c\test\src\main.cpp
 	"catch.hpp"
 
-1572249556 source:c:\project\uml-state-machine-in-c\src\hsm.c
+1576423042 source:c:\project\uml-state-machine-in-c\src\hsm.c
 	<stdint.h>
 	<stdbool.h>
 	<stdio.h>
 	"hsm.h"
 
-1572249556 c:\project\uml-state-machine-in-c\src\hsm.h
+1576423127 c:\project\uml-state-machine-in-c\src\hsm.h
 	"hsm_config.h"
 
-1572249556 c:\project\uml-state-machine-in-c\test\build\hsm_test\hsm_config.h
+1576425290 c:\project\uml-state-machine-in-c\test\build\hsm_test\hsm_config.h
 
-1572347415 source:c:\project\uml-state-machine-in-c\test\src\cases\hierarchical_state_transition.cpp
+1576421741 source:c:\project\uml-state-machine-in-c\test\src\cases\hierarchical_state_transition.cpp
 	"catch.hpp"
 	"hippomocks.h"
 	"hsm.h"
@@ -2894,7 +2894,7 @@
 	<algorithm>
 	<cassert>
 
-1572668547 c:\project\uml-state-machine-in-c\test\src\hippomocks.h
+1574574192 c:\project\uml-state-machine-in-c\test\src\hippomocks.h
 	<exception>
 	<cstdio>
 	<list>
@@ -2913,22 +2913,22 @@
 1572249556 source:c:\project\uml-state-machine-in-c\test\src\main.cpp
 	"catch.hpp"
 
-1572347744 source:c:\project\uml-state-machine-in-c\test\src\cases\hierarchical_test.cpp
+1576421741 source:c:\project\uml-state-machine-in-c\test\src\cases\hierarchical_test.cpp
 	"catch.hpp"
 	"hippomocks.h"
 	"hsm.h"
 
-1574563005 source:c:\project\uml-state-machine-in-c\test\src\cases\priority_test.cpp
+1576421741 source:c:\project\uml-state-machine-in-c\test\src\cases\priority_test.cpp
 	"catch.hpp"
 	"hippomocks.h"
 	"hsm.h"
 
-1574564510 source:c:\project\uml-state-machine-in-c\test\src\cases\simple_test.cpp
+1576421741 source:c:\project\uml-state-machine-in-c\test\src\cases\simple_test.cpp
 	"catch.hpp"
 	"hippomocks.h"
 	"hsm.h"
 
-1574564540 source:c:\project\uml-state-machine-in-c\test\src\cases\state_transition.cpp
+1576421741 source:c:\project\uml-state-machine-in-c\test\src\cases\state_transition.cpp
 	"catch.hpp"
 	"hsm.h"
 	"hippomocks.h"

--- a/test/build/hsm_test/codeclocks/hsm_test.layout
+++ b/test/build/hsm_test/codeclocks/hsm_test.layout
@@ -2,9 +2,19 @@
 <CodeBlocks_layout_file>
 	<FileVersion major="1" minor="0" />
 	<ActiveTarget name="Debug" />
-	<File name="..\..\..\src\main.cpp" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="..\..\..\..\src\hsm.h" open="1" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="53" topLine="0" />
+			<Cursor1 position="1171" topLine="28" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\src\cases\hierarchical_test.cpp" open="1" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="993" topLine="38" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\src\cases\hierarchical_state_transition.txt" open="1" top="0" tabpos="11" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1993" topLine="0" />
 		</Cursor>
 	</File>
 	<File name="..\..\..\src\cases\priority_test.cpp" open="1" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -12,14 +22,47 @@
 			<Cursor1 position="2261" topLine="78" />
 		</Cursor>
 	</File>
-	<File name="..\..\..\src\cases\hierarchical_state_transition.txt" open="0" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="..\hsm_config.h" open="1" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="2690" topLine="14" />
+			<Cursor1 position="337" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\src\cases\state_transition.cpp" open="1" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1248" topLine="42" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\src\hippomocks.h" open="1" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="87690" topLine="1955" />
+		</Cursor>
+		<Folding>
+			<Collapse line="3252" />
+		</Folding>
+	</File>
+	<File name="..\..\..\src\catch.hpp" open="1" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="118832" topLine="3426" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\src\cases\simple_test.cpp" open="1" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1652" topLine="53" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\..\src\hsm.c" open="1" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="6802" topLine="166" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\src\main.cpp" open="1" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="44" topLine="0" />
 		</Cursor>
 	</File>
 	<File name="..\..\..\src\cases\hierarchical_state_transition.cpp" open="1" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="5325" topLine="103" />
+			<Cursor1 position="5200" topLine="143" />
 		</Cursor>
 		<Folding>
 			<Collapse line="120" />
@@ -31,48 +74,5 @@
 			<Collapse line="208" />
 			<Collapse line="220" />
 		</Folding>
-	</File>
-	<File name="..\..\..\..\src\hsm.c" open="0" top="0" tabpos="0" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="7718" topLine="191" />
-		</Cursor>
-	</File>
-	<File name="..\..\..\src\catch.hpp" open="1" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="187612" topLine="5567" />
-		</Cursor>
-	</File>
-	<File name="..\hsm_config.h" open="0" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="237" topLine="0" />
-		</Cursor>
-	</File>
-	<File name="..\..\..\src\hippomocks.h" open="1" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="87690" topLine="1684" />
-		</Cursor>
-		<Folding>
-			<Collapse line="3252" />
-		</Folding>
-	</File>
-	<File name="..\..\..\src\cases\hierarchical_test.cpp" open="1" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="993" topLine="38" />
-		</Cursor>
-	</File>
-	<File name="..\..\..\src\cases\state_transition.cpp" open="1" top="1" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1248" topLine="42" />
-		</Cursor>
-	</File>
-	<File name="..\..\..\..\src\hsm.h" open="1" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1344" topLine="61" />
-		</Cursor>
-	</File>
-	<File name="..\..\..\src\cases\simple_test.cpp" open="1" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1652" topLine="53" />
-		</Cursor>
 	</File>
 </CodeBlocks_layout_file>


### PR DESCRIPTION
The use of variable-length array in the hsm.c is now optional. If the user wants to avoid this C language feature due to compiler issues or some other, he can disable it. 
The alternative implementation requires the user to manually provide highest hierarchical level among all the state machines in the project.