### PR TITLE
Feature/make unnamed struct optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ By default, the framework supports hierarchical state machine. Use "hsm_config.h
 Change the value of `HIERARCHICAL_STATES` (in the "hsm_config.h") to enable/disable **hierarchical state machine**.
 
 ```C
-// Enable the hierarchical state machine
 // 0 : disable hierarchical state machine. Only Finite state machine is supported.
 // 1 : enable Hierarchical state machine. Both finite and hierarchical state machine is supported.
 #define  HIERARCHICAL_STATES      0
@@ -189,7 +188,6 @@ Change the value of `STATE_MACHINE_LOGGER` to enable/disable state machine loggi
 By default, logging is disabled.
 
 ```C
-// Enable the state machine logging
 // 0: disable the state machine logger
 // 1: enable the state machine logger
 #define STATE_MACHINE_LOGGER     1
@@ -207,11 +205,25 @@ use `MAX_HIERARCHICAL_LEVEL` to set the maximum hierarchical level. This should 
 
 By default, framework uses variable length array implementation.
 ```C
-// Enable the state machine logging
+
 // 0: disable variable length array used in hsm.c
 // 1: enable variable length aray used in hsm.c
 #define HSM_USE_VARIABLE_LENGTH_ARRAY 1
 ```
+
+### Suppress anonymous structures
+
+The framework uses anonymous structure in `hierarchical_state_t` structure in hsm.h.
+If the compiler doesn't support this feature, it can be disabled by setting `HSM_USE_UNNAMED_STRUCT` to 0.
+
+By default, framework uses anonymous structure.
+
+```C
+// 0: disable anonymous structure in hsm.h
+// 1: Uses anonymous structure in hsm.h
+#define HSM_USE_UNNAMED_STRUCT 1
+```
+
 
 State machine logging
 ---------------------

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ If you disable "variable length array" then you need to manually provide the hig
 use `MAX_HIERARCHICAL_LEVEL` to set the maximum hierarchical level. This should be highest `state_t::Level` value among all the state machines.
 
 By default, framework uses variable length array implementation.
-```C
 
+```C
 // 0: disable variable length array used in hsm.c
 // 1: enable variable length aray used in hsm.c
 #define HSM_USE_VARIABLE_LENGTH_ARRAY 1

--- a/src/hsm.h
+++ b/src/hsm.h
@@ -32,6 +32,10 @@
 #define STATE_MACHINE_LOGGER     0        //!< Disable the logging of state machine
 #endif // STATE_MACHINE_LOGGER
 
+#ifndef HSM_USE_UNNAMED_STRUCT
+#define HSM_USE_UNNAMED_STRUCT 1
+#endif
+
 #ifndef HSM_USE_VARIABLE_LENGTH_ARRAY
 #define HSM_USE_VARIABLE_LENGTH_ARRAY 1
 #endif
@@ -64,7 +68,7 @@ typedef state_machine_result_t (*state_handler) (state_machine_t* const State);
 typedef void (*state_machine_event_logger)(uint32_t state_machine, uint32_t state, uint32_t event);
 typedef void (*state_machine_result_logger)(uint32_t state, state_machine_result_t result);
 
-// finite state structure
+//! finite state structure
 typedef struct finite_state_t{
   state_handler Handler;      //!< State handler function
   state_handler Entry;        //!< Entry action for state
@@ -75,7 +79,7 @@ typedef struct finite_state_t{
 #endif
 }finite_state_t;
 
-#ifndef __cplusplus
+ #if (!defined(__cplusplus) && (HSM_USE_UNNAMED_STRUCT == 1))
 //! Hierarchical state structure
 typedef struct hierarchical_state_t
 {

--- a/test/build/hsm_test/codeclocks/hsm_test.depend
+++ b/test/build/hsm_test/codeclocks/hsm_test.depend
@@ -2663,16 +2663,16 @@
 1539911761 source:e:\bala\project\uml-state-machine-in-c\test\src\main.cpp
 	"catch.hpp"
 
-1576423042 source:c:\project\uml-state-machine-in-c\src\hsm.c
+1576505329 source:c:\project\uml-state-machine-in-c\src\hsm.c
 	<stdint.h>
 	<stdbool.h>
 	<stdio.h>
 	"hsm.h"
 
-1576423127 c:\project\uml-state-machine-in-c\src\hsm.h
+1576506067 c:\project\uml-state-machine-in-c\src\hsm.h
 	"hsm_config.h"
 
-1576425290 c:\project\uml-state-machine-in-c\test\build\hsm_test\hsm_config.h
+1576506525 c:\project\uml-state-machine-in-c\test\build\hsm_test\hsm_config.h
 
 1576421741 source:c:\project\uml-state-machine-in-c\test\src\cases\hierarchical_state_transition.cpp
 	"catch.hpp"

--- a/test/build/hsm_test/codeclocks/hsm_test.layout
+++ b/test/build/hsm_test/codeclocks/hsm_test.layout
@@ -2,29 +2,24 @@
 <CodeBlocks_layout_file>
 	<FileVersion major="1" minor="0" />
 	<ActiveTarget name="Debug" />
-	<File name="..\..\..\..\src\hsm.h" open="1" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1171" topLine="28" />
-		</Cursor>
-	</File>
-	<File name="..\..\..\src\cases\hierarchical_test.cpp" open="1" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="993" topLine="38" />
-		</Cursor>
-	</File>
 	<File name="..\..\..\src\cases\hierarchical_state_transition.txt" open="1" top="0" tabpos="11" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="1993" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="..\..\..\src\cases\priority_test.cpp" open="1" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="..\..\..\..\src\hsm.c" open="1" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="2261" topLine="78" />
+			<Cursor1 position="0" topLine="0" />
 		</Cursor>
 	</File>
-	<File name="..\hsm_config.h" open="1" top="0" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="..\hsm_config.h" open="1" top="1" tabpos="10" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
 			<Cursor1 position="337" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\src\catch.hpp" open="1" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="118832" topLine="3445" />
 		</Cursor>
 	</File>
 	<File name="..\..\..\src\cases\state_transition.cpp" open="1" top="0" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -32,32 +27,9 @@
 			<Cursor1 position="1248" topLine="42" />
 		</Cursor>
 	</File>
-	<File name="..\..\..\src\hippomocks.h" open="1" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="..\..\..\src\cases\priority_test.cpp" open="1" top="0" tabpos="4" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="87690" topLine="1955" />
-		</Cursor>
-		<Folding>
-			<Collapse line="3252" />
-		</Folding>
-	</File>
-	<File name="..\..\..\src\catch.hpp" open="1" top="0" tabpos="6" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="118832" topLine="3426" />
-		</Cursor>
-	</File>
-	<File name="..\..\..\src\cases\simple_test.cpp" open="1" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="1652" topLine="53" />
-		</Cursor>
-	</File>
-	<File name="..\..\..\..\src\hsm.c" open="1" top="0" tabpos="9" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="6802" topLine="166" />
-		</Cursor>
-	</File>
-	<File name="..\..\..\src\main.cpp" open="1" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
-		<Cursor>
-			<Cursor1 position="44" topLine="0" />
+			<Cursor1 position="2261" topLine="78" />
 		</Cursor>
 	</File>
 	<File name="..\..\..\src\cases\hierarchical_state_transition.cpp" open="1" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
@@ -74,5 +46,33 @@
 			<Collapse line="208" />
 			<Collapse line="220" />
 		</Folding>
+	</File>
+	<File name="..\..\..\src\cases\hierarchical_test.cpp" open="1" top="0" tabpos="3" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="993" topLine="38" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\..\src\hsm.h" open="1" top="0" tabpos="8" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="825" topLine="25" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\src\main.cpp" open="1" top="0" tabpos="12" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="44" topLine="0" />
+		</Cursor>
+	</File>
+	<File name="..\..\..\src\hippomocks.h" open="1" top="0" tabpos="7" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="87690" topLine="2245" />
+		</Cursor>
+		<Folding>
+			<Collapse line="3252" />
+		</Folding>
+	</File>
+	<File name="..\..\..\src\cases\simple_test.cpp" open="1" top="0" tabpos="5" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+		<Cursor>
+			<Cursor1 position="1652" topLine="53" />
+		</Cursor>
 	</File>
 </CodeBlocks_layout_file>


### PR DESCRIPTION
This pull request adds the option to disable use of anonymous structure in hsm.h
This is useful if some compiler doesn't support this feature