### PR TITLE
Feature/travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+dist: trusty
+sudo: false
+language: cpp
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-6 
+
+script:
+  - CXX=/usr/bin/g++-6 CC=/usr/bin/gcc-6 cmake .
+  - cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-6 
+      - g++-8 
 
 script:
-  - CXX=/usr/bin/g++-6 CC=/usr/bin/gcc-6 cmake .
+  - CXX=/usr/bin/g++-6 CC=/usr/bin/gcc-8 cmake .
   - cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ addons:
 script:
   - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7
   - cd test/fsm_test
-  - md build
-  - cd build
-  - md MinGW
-  - cd MinGW
-  - cmake -G "MinGW Makefiles" ../..
+  - cmake -G "Unix Makefiles"
   - cmake --build .
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ addons:
       - cmake
 
 script:
-  - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake .
+  - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7
+  - cd test/fsm_test
+  - md build
+  - cd build
+  - md MinGW
+  - cd MinGW
+  - cmake -G "MinGW Makefiles" ../..
   - cmake --build .
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ addons:
 script:
   - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake .  
   - cmake --build .
-  - cd ${TRAVIS_BUILD_DIR}
-  - ls
   - ./test/fsm_test/fsm_UnitTest
-  - ./test/fsm_test/hsm_UnitTest
+  - ./test/hsm_test/hsm_UnitTest
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,6 @@ addons:
 script:
   - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake .  
   - cmake --build .
+  - ./fsm_UnitTest
+  - ./hsm_UnitTest
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,6 @@ addons:
       - cmake
 
 script:
-  - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7
-  - cd test/fsm_test
-  - cmake -G "Unix Makefiles" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
-  - ls
-  - cat hsm_config.h
+  - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake .  
   - cmake --build .
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-8 
+      - g++-7 
 
 script:
-  - CXX=/usr/bin/g++-6 CC=/usr/bin/gcc-8 cmake .
+  - CXX=/usr/bin/g++-6 CC=/usr/bin/gcc-7 cmake .
   - cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 dist: trusty
-sudo: false
+sudo: required
 language: cpp
+compiler: gcc
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - g++-7 
+      - gcc-7
+      - g++-7
+      - cmake
 
 script:
-  - CXX=/usr/bin/g++-6 CC=/usr/bin/gcc-7 cmake .
+  - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake .
   - cmake --build .
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ addons:
 script:
   - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7
   - cd test/fsm_test
-  - cmake -G "Unix Makefiles"
+  - cmake -G "Unix Makefiles" -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
+  - ls
+  - cat hsm_config.h
   - cmake --build .
  

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ addons:
 script:
   - CXX=/usr/bin/g++-7 CC=/usr/bin/gcc-7 cmake .  
   - cmake --build .
-  - ./fsm_UnitTest
-  - ./hsm_UnitTest
+  - cd ${TRAVIS_BUILD_DIR}
+  - ls
+  - ./test/fsm_test/fsm_UnitTest
+  - ./test/fsm_test/hsm_UnitTest
  

--- a/test/fsm_test/CMakeLists.txt
+++ b/test/fsm_test/CMakeLists.txt
@@ -33,12 +33,24 @@ include_directories(
 						${TARGET_DIR}
 					)
 
+set(CPP_VERSION 11)
+if ("cxx_std_14" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+	set(CPP_VERSION 14)
+endif()
 
-set(CMAKE_CXX_STANDARD 14)
+message("Your compiler supports : cpp${CPP_VERSION}")
+set(CMAKE_CXX_STANDARD ${CPP_VERSION})
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_C_STANDARD 11)
+set(C_VERSION 99)
+if ("c_std_11" IN_LIST CMAKE_C_COMPILE_FEATURES)
+	set(C_VERSION 11)
+endif()
+
+set(CMAKE_C_STANDARD ${C_VERSION})
 set(CMAKE_C_STANDARD_REQUIRED ON)
+message("Your compiler supports : c${C_VERSION}")
 
 set(HIERARCHICAL_STATES 0)
 

--- a/test/fsm_test/CMakeLists.txt
+++ b/test/fsm_test/CMakeLists.txt
@@ -57,11 +57,11 @@ set(HIERARCHICAL_STATES 0)
 add_executable(fsm_UnitTest ${TEST_FILES} ${TARGET_FILES} ${TESTCASE_FILES} ${HEADER_FILES})
 add_test(fsm_UnitTest fsm_UnitTest)
 
+set(HSM_USE_UNNAMED_STRUCT 0)
 
 if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )
     target_compile_options( fsm_UnitTest PRIVATE -Wall -Wextra -Wunreachable-code -Wpedantic )
     target_compile_options( fsm_UnitTest PRIVATE -Werror )
-	set(HSM_USE_UNNAMED_STRUCT 1)
 endif()
 
 # Clang specific options go here
@@ -73,7 +73,6 @@ if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     STRING(REGEX REPLACE "/W[0-9]" "/W4" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}) # override default warning level
     target_compile_options( fsm_UnitTest PRIVATE /w44265 /w44061 /w44062 /w45038 )
     target_compile_options( fsm_UnitTest PRIVATE /WX)
-	set(HSM_USE_UNNAMED_STRUCT 0)
 endif()
 
 target_compile_definitions(fsm_UnitTest PRIVATE HSM_CONFIG)

--- a/test/hsm_test/CMakeLists.txt
+++ b/test/hsm_test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
 set(HIERARCHICAL_STATES 1)
+set(HSM_USE_UNNAMED_STRUCT 0)
 
 add_executable(hsm_UnitTest ${TEST_FILES} ${TARGET_FILES} ${TESTCASE_FILES} ${HEADER_FILES})
 add_test(hsm_UnitTest hsm_UnitTest)
@@ -51,7 +52,6 @@ add_test(hsm_UnitTest hsm_UnitTest)
 if ( CMAKE_CXX_COMPILER_ID MATCHES "Clang|AppleClang|GNU" )
     target_compile_options( hsm_UnitTest PRIVATE -Wall -Wextra -Wunreachable-code -Wpedantic )
     target_compile_options( hsm_UnitTest PRIVATE -Werror )
-	set(HSM_USE_UNNAMED_STRUCT 1)
 	set(HSM_USE_VARIABLE_LENGTH_ARRAY 1)
 endif()
 
@@ -64,7 +64,6 @@ if ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     STRING(REGEX REPLACE "/W[0-9]" "/W4" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS}) # override default warning level
     target_compile_options( hsm_UnitTest PRIVATE /w44265 /w44061 /w44062 /w45038 )
     target_compile_options( hsm_UnitTest PRIVATE /WX)
-	set(HSM_USE_UNNAMED_STRUCT 0)
 	set(HSM_USE_VARIABLE_LENGTH_ARRAY 0)
 	set(MAX_HIERARCHICAL_LEVEL 3)
 endif()


### PR DESCRIPTION
Add Travis support the first step for continnuous integration. 
It builds and executes the FSM and HSM unit using cmake.